### PR TITLE
Projectile Pool bugfix

### DIFF
--- a/Flight Game/Assets/Prefabs/BulletRoot.prefab
+++ b/Flight Game/Assets/Prefabs/BulletRoot.prefab
@@ -58,7 +58,6 @@ GameObject:
   - component: {fileID: 7323896454525774918}
   - component: {fileID: 1652790763348574847}
   - component: {fileID: 4108370043978196467}
-  - component: {fileID: 2557201100280148647}
   m_Layer: 0
   m_Name: Bullet
   m_TagString: Projectile
@@ -154,16 +153,3 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &2557201100280148647
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4855934149383161003}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cf4df72476331524ea5c99a6f35969c9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _baseSpeed: 8

--- a/Flight Game/Assets/Prefabs/Target.prefab
+++ b/Flight Game/Assets/Prefabs/Target.prefab
@@ -97,7 +97,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea92bf832ac329948b387fd12cbe73e3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _countdownTimer: {fileID: 0}
+  countdownTimer: {fileID: 0}
   _material: {fileID: 2100000, guid: 4d31a95701afbec4f86c765fa62c169d, type: 2}
   _timerGain: 20
   _hits: 5

--- a/Flight Game/Assets/Scenes/Plane Asset.unity
+++ b/Flight Game/Assets/Scenes/Plane Asset.unity
@@ -320,7 +320,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _object: {fileID: 1823358977874895482, guid: 8e64bf863f1e9b141bdbecc84d6b3590, type: 3}
-  poolSize: 200
+  poolSize: 50
 --- !u!4 &199126404
 Transform:
   m_ObjectHideFlags: 0

--- a/Flight Game/Assets/Scenes/Plane Asset.unity
+++ b/Flight Game/Assets/Scenes/Plane Asset.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028328, g: 0.22571328, b: 0.3069218, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -348,7 +348,7 @@ GameObject:
   - component: {fileID: 286804905}
   m_Layer: 0
   m_Name: Chassis Collider
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1291,7 +1291,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _timerText: {fileID: 156379842}
-  _remainingTime: 10
+  _remainingTime: 100
   _gameOver: {fileID: 416650702}
 --- !u!224 &842892505
 RectTransform:
@@ -2035,7 +2035,7 @@ GameObject:
   - component: {fileID: 1174361616}
   m_Layer: 0
   m_Name: Wings Collider
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Flight Game/Assets/Scripts/Combat/ObjectPool.cs
+++ b/Flight Game/Assets/Scripts/Combat/ObjectPool.cs
@@ -10,25 +10,33 @@ public class ObjectPool : MonoBehaviour
 
     public int poolSize;
 
+    private int _validIndex;
+
     void Start()
     {
         _pool = new List<GameObject>();
         InitializeObjects();
+        _validIndex = 0;
     }
 
     public GameObject GetPooledObject()
     {
-        foreach(GameObject obj in _pool)
+
+        var obj = _pool[_validIndex];
+
+        for(int i = _validIndex + 1; i != _validIndex; i = ++i % poolSize)
         {
-            if (!obj.activeInHierarchy)
+            if (!_pool[i].activeInHierarchy)
             {
+                _validIndex = i;
                 obj.SetActive(true);
                 return obj;
             }
         }
-        int index = ResizePool();
-        _pool[index].SetActive(true);
-        return _pool[index];
+
+        _validIndex = ResizePool();
+        obj.SetActive(true);
+        return obj;
     }
 
     int ResizePool()

--- a/Flight Game/Assets/Scripts/Combat/ObjectPool.cs
+++ b/Flight Game/Assets/Scripts/Combat/ObjectPool.cs
@@ -24,11 +24,12 @@ public class ObjectPool : MonoBehaviour
 
         var obj = _pool[_validIndex];
 
-        for(int i = _validIndex + 1; i != _validIndex; i = ++i % poolSize)
+        for(int i = (_validIndex + 1) % poolSize; i != _validIndex; i = ++i % poolSize)
         {
             if (!_pool[i].activeInHierarchy)
             {
                 _validIndex = i;
+                Debug.Log(_validIndex);
                 obj.SetActive(true);
                 return obj;
             }
@@ -36,7 +37,9 @@ public class ObjectPool : MonoBehaviour
 
         _validIndex = ResizePool();
         obj.SetActive(true);
+        Debug.Log(_validIndex);
         return obj;
+        
     }
 
     int ResizePool()


### PR DESCRIPTION
~~Fixed the issue causing the projectile pool to be slow when instantiating objects after firing for a while, thus causing noticeable delays between new bullets~~
The actual bug was caused by the Projectile script being placed on both the bullet root and the child object, which caused disabling the child which would not get re-enabled.
Since we implemented the improvement to the pool, we might as well keep it