### PR TITLE
Implement waypoints

### DIFF
--- a/Flight Game/Assets/KevinCastejon.meta
+++ b/Flight Game/Assets/KevinCastejon.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a73e63e978b92a409733a685fb68d63
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flight Game/Assets/KevinCastejon/ConeMesh.meta
+++ b/Flight Game/Assets/KevinCastejon/ConeMesh.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: db4cfc3973c3695489576e642e13b836
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flight Game/Assets/KevinCastejon/ConeMesh/Core.meta
+++ b/Flight Game/Assets/KevinCastejon/ConeMesh/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dff9c48c9624eea49ab5149d0e00e939
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Cone.cs
+++ b/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Cone.cs
@@ -1,0 +1,179 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace KevinCastejon.ConeMesh
+{
+    public enum ConeOrientation
+    {
+        X,
+        Y,
+        Z
+    }
+
+    /// <summary>
+    /// Generate a cone mesh, renderer and collider, on the fly.
+    /// </summary>
+    [RequireComponent(typeof(MeshFilter), typeof(MeshRenderer), typeof(MeshCollider))]
+    public class Cone : MonoBehaviour
+    {
+        [SerializeField]
+        private bool _pivotAtTop = true;
+        [SerializeField]
+        private ConeOrientation _orientation = ConeOrientation.Z;
+        [SerializeField]
+        private bool _invertDirection;
+        [SerializeField]
+        private bool _isTrigger;
+        [SerializeField]
+        private Material _material;
+        [Min(3)]
+        [SerializeField]
+        private int _coneSides = 25;
+        [SerializeField]
+        private bool _proportionalRadius;
+        [Min(float.Epsilon)]
+        [SerializeField]
+        private float _coneRadius = 0.5f;
+        [SerializeField]
+        private float _coneHeight = 1f;
+
+        private Mesh _coneMesh;
+        private MeshFilter _meshFilter;
+        private MeshRenderer _meshRenderer;
+        private MeshCollider _meshCollider;
+
+        public bool PivotAtTop { get => _pivotAtTop; set { _pivotAtTop = value; GenerateCone(); } }
+        public Material Material { get => _material; set { _material = value; _meshRenderer = _meshRenderer ? _meshRenderer : gameObject.GetComponent<MeshRenderer>(); _meshRenderer.material = _material; } }
+        public int ConeSubdivisions { get => _coneSides; set { _coneSides = value; GenerateCone(); } }
+        public float ConeRadius { get => _coneRadius; set { _coneRadius = value; GenerateCone(); } }
+        public float ConeHeight { get => _coneHeight; set { _coneHeight = value; GenerateCone(); } }
+        public ConeOrientation Orientation { get => _orientation; set { _orientation = value; GenerateCone(); } }
+        public bool IsConeGenerated { get => _coneMesh != null; }
+        public bool IsTrigger
+        {
+            get => _isTrigger; set
+            {
+                _isTrigger = value; _meshCollider = _meshCollider ? _meshCollider : gameObject.GetComponent<MeshCollider>();
+                if (_isTrigger)
+                {
+                    _meshCollider.convex = true;
+                }
+                _meshCollider.isTrigger = value;
+            }
+        }
+        public bool ProportionalRadius { get => _proportionalRadius; set { _proportionalRadius = value; GenerateCone(); } }
+
+        private void Start()
+        {
+            GenerateCone();
+        }
+
+        internal void GenerateCone()
+        {
+            _coneMesh = CreateConeMesh(_coneSides + 1, _coneRadius, _coneHeight, _pivotAtTop, _orientation, _invertDirection, _proportionalRadius);
+            _meshFilter = _meshFilter ? _meshFilter : gameObject.GetComponent<MeshFilter>();
+            _meshRenderer = _meshRenderer ? _meshRenderer : gameObject.GetComponent<MeshRenderer>();
+            _meshCollider = _meshCollider ? _meshCollider : gameObject.GetComponent<MeshCollider>();
+
+            _meshFilter.sharedMesh = _coneMesh;
+
+            _meshRenderer.additionalVertexStreams = _coneMesh;
+            _meshRenderer.material = _material;
+            _meshCollider.sharedMesh = _coneMesh;
+            _meshCollider.convex = true;
+            _meshCollider.isTrigger = _isTrigger;
+        }
+
+        private static Mesh CreateConeMesh(int subdivisions, float radius, float height, bool pivotAtTop, ConeOrientation orientation, bool invertDirection, bool proportionalRadius)
+        {
+            if (proportionalRadius)
+            {
+                radius *= height;
+            }
+            if (invertDirection)
+            {
+                height = -height;
+            }
+            Mesh mesh = new Mesh();
+            Vector3[] vertices = new Vector3[subdivisions + 2];
+            Vector2[] uv = new Vector2[vertices.Length];
+            int[] triangles = new int[(subdivisions * 2) * 3];
+            if (orientation == ConeOrientation.X)
+            {
+                vertices[0] = pivotAtTop ? Vector3.right * height : Vector3.zero;
+            }
+            else if (orientation == ConeOrientation.Y)
+            {
+                vertices[0] = pivotAtTop ? Vector3.up * height : Vector3.zero;
+            }
+            else
+            {
+                vertices[0] = pivotAtTop ? Vector3.forward * height : Vector3.zero;
+            }
+            uv[0] = new Vector2(0.5f, 0f);
+            for (int i = 0, n = subdivisions - 1; i < subdivisions; i++)
+            {
+                float ratio = (float)i / n;
+                float r = ratio * (Mathf.PI * 2f);
+                float x = Mathf.Cos(r) * radius;
+                float z = Mathf.Sin(r) * radius;
+                if (orientation == ConeOrientation.X)
+                {
+                    vertices[i + 1] = new Vector3(pivotAtTop ? height : 0f, x, z);
+                }
+                else if (orientation == ConeOrientation.Y)
+                {
+                    vertices[i + 1] = new Vector3(x, pivotAtTop ? height : 0f, z);
+                }
+                else
+                {
+                    vertices[i + 1] = new Vector3(x, z, pivotAtTop ? height : 0f);
+                }
+                uv[i + 1] = new Vector2(ratio, 0f);
+            }
+            if (orientation == ConeOrientation.X)
+            {
+                vertices[subdivisions + 1] = !pivotAtTop ? Vector3.right * height : Vector3.zero;
+            }
+            else if (orientation == ConeOrientation.Y)
+            {
+                vertices[subdivisions + 1] = !pivotAtTop ? Vector3.up * height : Vector3.zero;
+            }
+            else
+            {
+                vertices[subdivisions + 1] = !pivotAtTop ? Vector3.forward * height : Vector3.zero;
+            }
+            uv[subdivisions + 1] = new Vector2(0.5f, 1f);
+
+            // base
+
+            for (int i = 0, n = subdivisions - 1; i < n; i++)
+            {
+                int offset = i * 3;
+                triangles[offset] = 0;
+                triangles[offset + 1] = i + 1;
+                triangles[offset + 2] = i + 2;
+            }
+
+            // sides
+
+            int bottomOffset = subdivisions * 3;
+            for (int i = 0, n = subdivisions - 1; i < n; i++)
+            {
+                int offset = i * 3 + bottomOffset;
+                triangles[offset] = i + 1;
+                triangles[offset + 1] = subdivisions + 1;
+                triangles[offset + 2] = i + 2;
+            }
+
+            mesh.vertices = vertices;
+            mesh.uv = uv;
+            mesh.triangles = triangles;
+            mesh.RecalculateBounds();
+            mesh.RecalculateNormals();
+
+            return mesh;
+        }
+    }
+}

--- a/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Cone.cs.meta
+++ b/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Cone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 937e112073adb0b47afd6614fb11af14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flight Game/Assets/KevinCastejon/ConeMesh/Core/ConeMeshAssembly.asmdef
+++ b/Flight Game/Assets/KevinCastejon/ConeMesh/Core/ConeMeshAssembly.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "ConeMeshAssembly",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Flight Game/Assets/KevinCastejon/ConeMesh/Core/ConeMeshAssembly.asmdef.meta
+++ b/Flight Game/Assets/KevinCastejon/ConeMesh/Core/ConeMeshAssembly.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1eaa79df54abda04295ca027d7ba718f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flight Game/Assets/KevinCastejon/ConeMesh/Core/ConeNamespaceExporter.cs
+++ b/Flight Game/Assets/KevinCastejon/ConeMesh/Core/ConeNamespaceExporter.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("ConeMeshEditorAssembly")]
+namespace KevinCastejon.ConeMesh { }

--- a/Flight Game/Assets/KevinCastejon/ConeMesh/Core/ConeNamespaceExporter.cs.meta
+++ b/Flight Game/Assets/KevinCastejon/ConeMesh/Core/ConeNamespaceExporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58ef1c47bd3a93a408c2cd65952a30fa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Editor.meta
+++ b/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70f125c5d09335f43be3e8bb9944d724
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Editor/ConeEditor.cs
+++ b/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Editor/ConeEditor.cs
@@ -1,0 +1,82 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace KevinCastejon.ConeMesh
+{
+    [CustomEditor(typeof(Cone))]
+    public class ConeEditor : Editor
+    {
+        private SerializedProperty _pivotAtTop;
+        private SerializedProperty _orientation;
+        private SerializedProperty _invertDirection;
+        private SerializedProperty _isTrigger;
+        private SerializedProperty _material;
+        private SerializedProperty _coneSides;
+        private SerializedProperty _proportionalRadius;
+        private SerializedProperty _coneRadius;
+        private SerializedProperty _coneHeight;
+
+        private Cone _script;
+
+        private void OnEnable()
+        {
+            _pivotAtTop = serializedObject.FindProperty("_pivotAtTop");
+            _orientation = serializedObject.FindProperty("_orientation");
+            _invertDirection = serializedObject.FindProperty("_invertDirection");
+            _isTrigger = serializedObject.FindProperty("_isTrigger");
+            _material = serializedObject.FindProperty("_material");
+            _coneSides = serializedObject.FindProperty("_coneSides");
+            _proportionalRadius = serializedObject.FindProperty("_proportionalRadius");
+            _coneRadius = serializedObject.FindProperty("_coneRadius");
+            _coneHeight = serializedObject.FindProperty("_coneHeight");
+
+            _script = (Cone)target;
+            if (!_script.IsConeGenerated)
+            {
+                _script.GenerateCone();
+            }
+        }
+
+        public override void OnInspectorGUI()
+        {
+            bool changed;
+            serializedObject.Update();
+            EditorGUI.BeginChangeCheck();
+            EditorGUILayout.PropertyField(_pivotAtTop);
+            EditorGUILayout.PropertyField(_orientation);
+            EditorGUILayout.PropertyField(_invertDirection);
+            EditorGUILayout.PropertyField(_isTrigger);
+            EditorGUILayout.PropertyField(_material);
+            EditorGUILayout.PropertyField(_coneSides);
+            EditorGUILayout.PropertyField(_proportionalRadius);
+            EditorGUILayout.PropertyField(_coneRadius);
+            EditorGUILayout.PropertyField(_coneHeight);
+            changed = EditorGUI.EndChangeCheck();
+            serializedObject.ApplyModifiedProperties();
+            if (changed)
+            {
+                _script.GenerateCone();
+            }
+        }
+        // Add a menu item to create custom GameObjects.
+        // Priority 1 ensures it is grouped with the other menu items of the same kind
+        // and propagated to the hierarchy dropdown and hierarchy context menus.
+        [MenuItem("GameObject/3D Object/Cone", false, 10)]
+        static void CreateCustomGameObject(MenuCommand menuCommand)
+        {
+            // Create a custom game object
+            GameObject go = new GameObject("Cone");
+            // Add Cone component
+            Cone cone = go.AddComponent<Cone>();
+            // Set default lit material
+            cone.Material = new Material(Shader.Find("Unlit/Color"));
+            // Ensure it gets reparented if this was a context click (otherwise does nothing)
+            GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
+            // Register the creation in the undo system
+            Undo.RegisterCreatedObjectUndo(go, "Create " + go.name);
+            Selection.activeObject = go;
+        }
+    }
+}

--- a/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Editor/ConeEditor.cs.meta
+++ b/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Editor/ConeEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 567af5490f3f7c745a71ce0d3c6aa817
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Editor/ConeMeshEditorAssembly.asmdef
+++ b/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Editor/ConeMeshEditorAssembly.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "ConeMeshEditorAssembly",
+    "rootNamespace": "",
+    "references": [
+        "GUID:1eaa79df54abda04295ca027d7ba718f"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Editor/ConeMeshEditorAssembly.asmdef.meta
+++ b/Flight Game/Assets/KevinCastejon/ConeMesh/Core/Editor/ConeMeshEditorAssembly.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 95ce7587b9336c447a75a7349dd347eb
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flight Game/Assets/Materials/Portal.mat
+++ b/Flight Game/Assets/Materials/Portal.mat
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-4071323298736532243
+--- !u!114 &-8824441433167817865
 MonoBehaviour:
   m_ObjectHideFlags: 11
   m_CorrespondingSourceObject: {fileID: 0}
@@ -20,33 +20,29 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Snow
-  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Name: Portal
+  m_Shader: {fileID: 4800000, guid: 5891a40a791bd5f438877f0f754a4adc, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords:
+  m_ValidKeywords: []
+  m_InvalidKeywords:
   - _EMISSION
-  - _NORMALMAP
-  - _OCCLUSIONMAP
-  - _PARALLAXMAP
-  m_InvalidKeywords: []
   m_LightmapFlags: 1
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
-  stringTagMap:
-    RenderType: Opaque
+  stringTagMap: {}
   disabledShaderPasses: []
   m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
     - _BaseMap:
-        m_Texture: {fileID: 2800000, guid: 1f27a16ed04f7e0499cca9e2d233da4c, type: 3}
-        m_Scale: {x: 5, y: 5}
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _BumpMap:
-        m_Texture: {fileID: 2800000, guid: 310d1ec2ed5c49b4abeeb1835a5d28c2, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _DetailAlbedoMap:
@@ -63,22 +59,22 @@ Material:
         m_Offset: {x: 0, y: 0}
     - _EmissionMap:
         m_Texture: {fileID: 0}
-        m_Scale: {x: 2, y: 2}
+        m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 1f27a16ed04f7e0499cca9e2d233da4c, type: 3}
-        m_Scale: {x: 5, y: 5}
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _OcclusionMap:
-        m_Texture: {fileID: 2800000, guid: 7862c6a7adea56e44949c5039b1a8f5e, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _ParallaxMap:
-        m_Texture: {fileID: 2800000, guid: 690a12b77a6c8684fa83eba813b1d433, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _SpecGlossMap:
@@ -103,7 +99,7 @@ Material:
     - _AlphaToMask: 0
     - _Blend: 0
     - _BlendModePreserveSpecular: 1
-    - _BumpScale: 0.4
+    - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
     - _Cull: 2
@@ -116,23 +112,22 @@ Material:
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
-    - _Metallic: 0.022
-    - _Mode: 0
-    - _OcclusionStrength: 0.319
-    - _Parallax: 0.08
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
     - _QueueOffset: 0
     - _ReceiveShadows: 1
-    - _Smoothness: 0.612
+    - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
     - _Surface: 0
-    - _UVSec: 0
+    - _WireThickness: 100
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
-    - _BaseColor: {r: 0.40392157, g: 0.019607844, b: 0.08627451, a: 1}
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}

--- a/Flight Game/Assets/Materials/Portal.mat.meta
+++ b/Flight Game/Assets/Materials/Portal.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22b379cbf0357534ca5d8e5d39ea239b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flight Game/Assets/Prefabs/Checkpoint.prefab
+++ b/Flight Game/Assets/Prefabs/Checkpoint.prefab
@@ -32,7 +32,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 10, y: 10, z: 10}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 6191933385322698280}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &2499481733964965733
@@ -123,3 +124,101 @@ MonoBehaviour:
   timerGain: 10
   scoreGain: 100
   _scoreCounter: {fileID: 11400000, guid: a26bdaab31ee09847b7d6acc804d23fa, type: 2}
+--- !u!1 &6488252994746956878
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6191933385322698280}
+  - component: {fileID: 1700226703329578664}
+  - component: {fileID: 641485276977840979}
+  - component: {fileID: 7151977477961885369}
+  m_Layer: 0
+  m_Name: Waypoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6191933385322698280
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6488252994746956878}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 100, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1202343788270755371}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1700226703329578664
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6488252994746956878}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 4c9d8e3b773560b46a56ccb73549a710, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &641485276977840979
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6488252994746956878}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &7151977477961885369
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6488252994746956878}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 139e0193184c72d4ca4860f7b2a3092e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _plane: {fileID: 0}
+  _activationDistance: 50

--- a/Flight Game/Assets/Prefabs/Checkpoint.prefab
+++ b/Flight Game/Assets/Prefabs/Checkpoint.prefab
@@ -153,7 +153,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.5, y: 100, z: 0.5}
+  m_LocalScale: {x: 0.5, y: 20, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1202343788270755371}

--- a/Flight Game/Assets/Prefabs/Portal.prefab
+++ b/Flight Game/Assets/Prefabs/Portal.prefab
@@ -30,10 +30,10 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_LocalScale: {x: 30, y: 30, z: 30}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3207329139236828960}
+  - {fileID: 8226024083873080969}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &2499481733964965733
@@ -56,7 +56,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 15303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 22b379cbf0357534ca5d8e5d39ea239b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -124,7 +124,8 @@ MonoBehaviour:
   timerGain: 20
   scoreGain: 1000
   _scoreCounter: {fileID: 11400000, guid: a26bdaab31ee09847b7d6acc804d23fa, type: 2}
---- !u!1 &4229737560023997817
+  _waypoint: {fileID: 8900662837559913722}
+--- !u!1 &8900662837559913722
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -132,10 +133,11 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3207329139236828960}
-  - component: {fileID: 417706009840260058}
-  - component: {fileID: 882471168080095585}
-  - component: {fileID: 4988697933812912883}
+  - component: {fileID: 8226024083873080969}
+  - component: {fileID: 9101671577367224732}
+  - component: {fileID: 1732640164364671722}
+  - component: {fileID: 3700738244350532837}
+  - component: {fileID: 3017466436667764448}
   m_Layer: 0
   m_Name: Waypoint
   m_TagString: Untagged
@@ -143,36 +145,36 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &3207329139236828960
+--- !u!4 &8226024083873080969
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4229737560023997817}
+  m_GameObject: {fileID: 8900662837559913722}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.5, y: 100, z: 0.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1202343788270755371}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &417706009840260058
+--- !u!33 &9101671577367224732
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4229737560023997817}
-  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &882471168080095585
+  m_GameObject: {fileID: 8900662837559913722}
+  m_Mesh: {fileID: 0}
+--- !u!23 &1732640164364671722
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4229737560023997817}
+  m_GameObject: {fileID: 8900662837559913722}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -208,17 +210,46 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!114 &4988697933812912883
+--- !u!64 &3700738244350532837
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8900662837559913722}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 0}
+--- !u!114 &3017466436667764448
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4229737560023997817}
+  m_GameObject: {fileID: 8900662837559913722}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 139e0193184c72d4ca4860f7b2a3092e, type: 3}
+  m_Script: {fileID: 11500000, guid: 937e112073adb0b47afd6614fb11af14, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _plane: {fileID: 0}
-  _activationDistance: 10
+  _pivotAtTop: 1
+  _orientation: 1
+  _invertDirection: 1
+  _isTrigger: 1
+  _material: {fileID: 2100000, guid: 4c9d8e3b773560b46a56ccb73549a710, type: 2}
+  _coneSides: 25
+  _proportionalRadius: 1
+  _coneRadius: 1
+  _coneHeight: 20

--- a/Flight Game/Assets/Prefabs/Portal.prefab
+++ b/Flight Game/Assets/Prefabs/Portal.prefab
@@ -32,7 +32,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 10, y: 10, z: 10}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 3207329139236828960}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &2499481733964965733
@@ -123,3 +124,101 @@ MonoBehaviour:
   timerGain: 20
   scoreGain: 1000
   _scoreCounter: {fileID: 11400000, guid: a26bdaab31ee09847b7d6acc804d23fa, type: 2}
+--- !u!1 &4229737560023997817
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3207329139236828960}
+  - component: {fileID: 417706009840260058}
+  - component: {fileID: 882471168080095585}
+  - component: {fileID: 4988697933812912883}
+  m_Layer: 0
+  m_Name: Waypoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3207329139236828960
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4229737560023997817}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 100, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1202343788270755371}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &417706009840260058
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4229737560023997817}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &882471168080095585
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4229737560023997817}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 4c9d8e3b773560b46a56ccb73549a710, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &4988697933812912883
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4229737560023997817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 139e0193184c72d4ca4860f7b2a3092e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _plane: {fileID: 0}
+  _activationDistance: 10

--- a/Flight Game/Assets/Scenes/Main Scene.unity
+++ b/Flight Game/Assets/Scenes/Main Scene.unity
@@ -3045,6 +3045,7 @@ MonoBehaviour:
   _lateralRadius: 40
   _waterLevel: {fileID: 1903168319}
   _heightRadius: 50
+  _portalHeight: 75
   _terrainLayers:
     serializedVersion: 2
     m_Bits: 64

--- a/Flight Game/Assets/Scenes/Main Scene.unity
+++ b/Flight Game/Assets/Scenes/Main Scene.unity
@@ -835,6 +835,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Checkpoint
       objectReference: {fileID: 0}
+    - target: {fileID: 7151977477961885369, guid: 84e1524a5e883af40bb9feedb2dfaf36,
+        type: 3}
+      propertyPath: _plane
+      value: 
+      objectReference: {fileID: 908505397}
     - target: {fileID: 8667647573171359797, guid: 84e1524a5e883af40bb9feedb2dfaf36,
         type: 3}
       propertyPath: generator
@@ -3545,7 +3550,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _timerText: {fileID: 2114798718}
-  _startingTime: 10
+  _startingTime: 100
   _gameOver: {fileID: 908271671}
   _scorePerSecond: 10
   _scoreCounter: {fileID: 11400000, guid: a26bdaab31ee09847b7d6acc804d23fa, type: 2}

--- a/Flight Game/Assets/Scenes/Main Scene.unity
+++ b/Flight Game/Assets/Scenes/Main Scene.unity
@@ -3550,7 +3550,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _timerText: {fileID: 2114798718}
-  _startingTime: 100
+  _startingTime: 15
   _gameOver: {fileID: 908271671}
   _scorePerSecond: 10
   _scoreCounter: {fileID: 11400000, guid: a26bdaab31ee09847b7d6acc804d23fa, type: 2}

--- a/Flight Game/Assets/Scripts/Checkpoints/Checkpoint.cs
+++ b/Flight Game/Assets/Scripts/Checkpoints/Checkpoint.cs
@@ -9,7 +9,7 @@ public class Checkpoint : MonoBehaviour
     public int scoreGain;
     
     [SerializeField]
-    private ScoreCounterSO _scoreCounter;
+    protected ScoreCounterSO _scoreCounter;
     protected virtual void OnTriggerEnter(Collider other)
     {
         if (other.gameObject.CompareTag(Constants.PlayerTag)){

--- a/Flight Game/Assets/Scripts/Checkpoints/CheckpointGenerator.cs
+++ b/Flight Game/Assets/Scripts/Checkpoints/CheckpointGenerator.cs
@@ -40,6 +40,10 @@ public class CheckpointGenerator : MonoBehaviour
     [SerializeField]
     private float _heightRadius;
 
+    [Tooltip("Portal placement height, counting from water level")]
+    [SerializeField]
+    private float _portalHeight;
+
     [Tooltip("Which layers constitute the terrain")]
     [SerializeField]
     private LayerMask _terrainLayers;
@@ -74,8 +78,7 @@ public class CheckpointGenerator : MonoBehaviour
         {
             float directionOffset = Random.Range(_minRadius, _maxRadius);
             float lateralOffset = Random.Range(-_lateralRadius, _lateralRadius);
-            float height = Random.Range(_minHeight, _maxHeight);
-
+            float height = portal ? _minHeight + _portalHeight : Random.Range(_minHeight, _maxHeight);
             Vector2 pOffset = Vector2.Perpendicular(new Vector2(direction.x, direction.z)) * lateralOffset;
 
             Vector3 offset = direction * directionOffset +

--- a/Flight Game/Assets/Scripts/Checkpoints/Portal.cs
+++ b/Flight Game/Assets/Scripts/Checkpoints/Portal.cs
@@ -15,6 +15,7 @@ public class Portal : Checkpoint
         {
             generator.terrainController.ChangeNoiseTexture();
             generator.switcher.SwitchDimension();
+            _scoreCounter.score.portals += 1;
 
             _waypoint.SetActive(false);
             _entered = true;

--- a/Flight Game/Assets/Scripts/Checkpoints/Portal.cs
+++ b/Flight Game/Assets/Scripts/Checkpoints/Portal.cs
@@ -4,13 +4,20 @@ using UnityEngine;
 [RequireComponent(typeof(Collider))]
 public class Portal : Checkpoint
 {
+    [SerializeField]
+    private GameObject _waypoint;
+
+    private bool _entered;
+
     protected override void OnTriggerEnter(Collider other)
     {
-        if (other.gameObject.CompareTag(Constants.PlayerTag))
+        if (!_entered && other.gameObject.CompareTag(Constants.PlayerTag))
         {
             generator.terrainController.ChangeNoiseTexture();
             generator.switcher.SwitchDimension();
 
+            _waypoint.SetActive(false);
+            _entered = true;
             StartCoroutine(BaseCoroutine(other));
         }
     }
@@ -20,7 +27,7 @@ public class Portal : Checkpoint
     //Giving it a slight delay is a simple, albeit hack-ish fix.
     private IEnumerator BaseCoroutine(Collider other)
     {
-        yield return new WaitForSeconds(0.5f);
+        yield return new WaitForSeconds(0.75f);
         base.OnTriggerEnter(other);
     } 
 }

--- a/Flight Game/Assets/Scripts/Checkpoints/Portal.cs
+++ b/Flight Game/Assets/Scripts/Checkpoints/Portal.cs
@@ -13,22 +13,12 @@ public class Portal : Checkpoint
     {
         if (!_entered && other.gameObject.CompareTag(Constants.PlayerTag))
         {
-            generator.terrainController.ChangeNoiseTexture();
+            generator.terrainController.ChangeNoiseTexture(() => base.OnTriggerEnter(other));
             generator.switcher.SwitchDimension();
             _scoreCounter.score.portals += 1;
 
             _waypoint.SetActive(false);
             _entered = true;
-            StartCoroutine(BaseCoroutine(other));
         }
     }
-
-    //If we try and spawn the new checkpoint right after we switch dimensions
-    //it will break because it can't find the previous tiles
-    //Giving it a slight delay is a simple, albeit hack-ish fix.
-    private IEnumerator BaseCoroutine(Collider other)
-    {
-        yield return new WaitForSeconds(0.75f);
-        base.OnTriggerEnter(other);
-    } 
 }

--- a/Flight Game/Assets/Scripts/Checkpoints/ProximityWaypoint.cs
+++ b/Flight Game/Assets/Scripts/Checkpoints/ProximityWaypoint.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[RequireComponent(typeof(MeshRenderer))]
+public class ProximityWaypoint : MonoBehaviour
+{
+    [SerializeField]
+    private Transform _plane;
+
+    [SerializeField]
+    private float _activationDistance;
+
+    private MeshRenderer _meshRenderer;
+
+    private void Awake()
+    {
+        _meshRenderer = GetComponent<MeshRenderer>();
+        _plane = GameObject.FindGameObjectWithTag("Player").transform;
+    }
+
+    void Update()
+    {
+        float distance = Vector3.Distance(new Vector3(transform.position.x, 0, transform.position.z),
+                                          new Vector3(_plane.position.x, 0, _plane.position.z));
+        if (distance >= _activationDistance)
+        {
+            _meshRenderer.enabled = true;
+        }
+        else
+        {
+            _meshRenderer.enabled = false;   
+        }
+    }
+}

--- a/Flight Game/Assets/Scripts/Checkpoints/ProximityWaypoint.cs.meta
+++ b/Flight Game/Assets/Scripts/Checkpoints/ProximityWaypoint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 139e0193184c72d4ca4860f7b2a3092e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flight Game/Assets/Scripts/Game/ScoreCounterSO.cs
+++ b/Flight Game/Assets/Scripts/Game/ScoreCounterSO.cs
@@ -13,6 +13,7 @@ public class ScoreCounterSO : ScriptableObject
         public int time = 0;
         public int checkpoints = 0;
         public int targets = 0;
+        public int portals = 0;
         public string gameOver = "";
     }
 

--- a/Flight Game/Assets/Scripts/Terrain/TerrainController.cs
+++ b/Flight Game/Assets/Scripts/Terrain/TerrainController.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using Unity.VisualScripting;
 using UnityEngine;
 
 public class TerrainController : MonoBehaviour {
@@ -108,7 +106,7 @@ public class TerrainController : MonoBehaviour {
         return newTexture;
     }
 
-    public void ChangeNoiseTexture()
+    public void ChangeNoiseTexture(System.Action callback)
     {
         // Update the noise texture and pixels
         _noise = GetRandomTexture();
@@ -119,6 +117,8 @@ public class TerrainController : MonoBehaviour {
         _noiseRange = _usePerlinNoise ? Vector2.one * 256 : new Vector2(noisePixels.Length, noisePixels[0].Length);
 
         DestroyTerrain();
+        Update();
+        callback();
     }
 
     public void InitialLoad() {
@@ -271,7 +271,7 @@ public class TerrainController : MonoBehaviour {
     public void DestroyTerrain() {
         _water.parent = null;
         _playerTransform.parent = null;
-
+        _previousCenterTiles = null;
         if (Level != null)
         {
             foreach (Transform t in _gameTransforms)

--- a/Flight Game/Assets/Shaders.meta
+++ b/Flight Game/Assets/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c0dc5d7ebc1ab624c921f4800807a41d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flight Game/Assets/Shaders/Portal.shader
+++ b/Flight Game/Assets/Shaders/Portal.shader
@@ -1,0 +1,145 @@
+// Unity built-in shader source. Copyright (c) 2016 Unity Technologies. MIT license (see license.txt)
+// Edited to disable Face Culling
+Shader "Custom/Portal"
+{
+    Properties
+    {
+        _WireThickness ("Wire Thickness", RANGE(0, 800)) = 100
+    }
+
+    SubShader
+    {
+        // Each color represents a meter.
+
+        Cull Off
+        Tags { "RenderType"="Opaque" }
+
+        Pass
+        {
+            // Wireframe shader based on the the following
+            // http://developer.download.nvidia.com/SDK/10/direct3d/Source/SolidWireframe/Doc/SolidWireframe.pdf
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma geometry geom
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            float _WireThickness;
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2g
+            {
+                float4 projectionSpaceVertex : SV_POSITION;
+                float4 worldSpacePosition : TEXCOORD1;
+                UNITY_VERTEX_OUTPUT_STEREO_EYE_INDEX
+            };
+
+            struct g2f
+            {
+                float4 projectionSpaceVertex : SV_POSITION;
+                float4 worldSpacePosition : TEXCOORD0;
+                float4 dist : TEXCOORD1;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2g vert (appdata v)
+            {
+                v2g o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_OUTPUT_STEREO_EYE_INDEX(o);
+
+                o.projectionSpaceVertex = UnityObjectToClipPos(v.vertex);
+                o.worldSpacePosition = mul(unity_ObjectToWorld, v.vertex);
+                return o;
+            }
+
+            [maxvertexcount(3)]
+            void geom(triangle v2g i[3], inout TriangleStream<g2f> triangleStream)
+            {
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i[0]);
+
+                float2 p0 = i[0].projectionSpaceVertex.xy / i[0].projectionSpaceVertex.w;
+                float2 p1 = i[1].projectionSpaceVertex.xy / i[1].projectionSpaceVertex.w;
+                float2 p2 = i[2].projectionSpaceVertex.xy / i[2].projectionSpaceVertex.w;
+
+                float2 edge0 = p2 - p1;
+                float2 edge1 = p2 - p0;
+                float2 edge2 = p1 - p0;
+
+                // To find the distance to the opposite edge, we take the
+                // formula for finding the area of a triangle Area = Base/2 * Height,
+                // and solve for the Height = (Area * 2)/Base.
+                // We can get the area of a triangle by taking its cross product
+                // divided by 2.  However we can avoid dividing our area/base by 2
+                // since our cross product will already be double our area.
+                float area = abs(edge1.x * edge2.y - edge1.y * edge2.x);
+                float wireThickness = 800 - _WireThickness;
+
+                g2f o;
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.worldSpacePosition = i[0].worldSpacePosition;
+                o.projectionSpaceVertex = i[0].projectionSpaceVertex;
+                o.dist.xyz = float3( (area / length(edge0)), 0.0, 0.0) * o.projectionSpaceVertex.w * wireThickness;
+                o.dist.w = 1.0 / o.projectionSpaceVertex.w;
+                triangleStream.Append(o);
+
+                o.worldSpacePosition = i[1].worldSpacePosition;
+                o.projectionSpaceVertex = i[1].projectionSpaceVertex;
+                o.dist.xyz = float3(0.0, (area / length(edge1)), 0.0) * o.projectionSpaceVertex.w * wireThickness;
+                o.dist.w = 1.0 / o.projectionSpaceVertex.w;
+                triangleStream.Append(o);
+
+                o.worldSpacePosition = i[2].worldSpacePosition;
+                o.projectionSpaceVertex = i[2].projectionSpaceVertex;
+                o.dist.xyz = float3(0.0, 0.0, (area / length(edge2))) * o.projectionSpaceVertex.w * wireThickness;
+                o.dist.w = 1.0 / o.projectionSpaceVertex.w;
+                triangleStream.Append(o);
+            }
+
+            fixed4 frag (g2f i) : SV_Target
+            {
+                float minDistanceToEdge = min(i.dist[0], min(i.dist[1], i.dist[2])) * i.dist[3];
+
+                // Early out if we know we are not on a line segment.
+                if(minDistanceToEdge > 0.9)
+                {
+                    return fixed4(0,0,0,0);
+                }
+
+                // Smooth our line out
+                float t = exp2(-2 * minDistanceToEdge * minDistanceToEdge);
+
+                const fixed4 colors[11] = {
+                        fixed4(1.0, 1.0, 1.0, 1.0),  // White
+                        fixed4(1.0, 0.0, 0.0, 1.0),  // Red
+                        fixed4(0.0, 1.0, 0.0, 1.0),  // Green
+                        fixed4(0.0, 0.0, 1.0, 1.0),  // Blue
+                        fixed4(1.0, 1.0, 0.0, 1.0),  // Yellow
+                        fixed4(0.0, 1.0, 1.0, 1.0),  // Cyan/Aqua
+                        fixed4(1.0, 0.0, 1.0, 1.0),  // Magenta
+                        fixed4(0.5, 0.0, 0.0, 1.0),  // Maroon
+                        fixed4(0.0, 0.5, 0.5, 1.0),  // Teal
+                        fixed4(1.0, 0.65, 0.0, 1.0), // Orange
+                        fixed4(1.0, 1.0, 1.0, 1.0)   // White
+                    };
+
+                float cameraToVertexDistance = length(_WorldSpaceCameraPos - i.worldSpacePosition);
+                int index = clamp(floor(cameraToVertexDistance), 0, 10);
+                fixed4 wireColor = colors[index];
+
+                fixed4 finalColor = lerp(float4(0,0,0,1), wireColor, t);
+                finalColor.a = t;
+
+                return finalColor;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Flight Game/Assets/Shaders/Portal.shader.meta
+++ b/Flight Game/Assets/Shaders/Portal.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5891a40a791bd5f438877f0f754a4adc
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flight Game/ProjectSettings/Packages/com.unity.probuilder/Settings.json
+++ b/Flight Game/ProjectSettings/Packages/com.unity.probuilder/Settings.json
@@ -1,0 +1,31 @@
+{
+    "m_Dictionary": {
+        "m_DictionaryValues": [
+            {
+                "type": "UnityEngine.ProBuilder.LogLevel, Unity.ProBuilder, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                "key": "log.level",
+                "value": "{\"m_Value\":3}"
+            },
+            {
+                "type": "UnityEngine.ProBuilder.LogOutput, Unity.ProBuilder, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                "key": "log.output",
+                "value": "{\"m_Value\":1}"
+            },
+            {
+                "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "log.path",
+                "value": "{\"m_Value\":\"ProBuilderLog.txt\"}"
+            },
+            {
+                "type": "UnityEngine.ProBuilder.SemVer, Unity.ProBuilder, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                "key": "about.identifier",
+                "value": "{\"m_Value\":{\"m_Major\":5,\"m_Minor\":1,\"m_Patch\":1,\"m_Build\":-1,\"m_Type\":\"\",\"m_Metadata\":\"\",\"m_Date\":\"\"}}"
+            },
+            {
+                "type": "UnityEngine.ProBuilder.SemVer, Unity.ProBuilder, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                "key": "preferences.version",
+                "value": "{\"m_Value\":{\"m_Major\":5,\"m_Minor\":1,\"m_Patch\":1,\"m_Build\":-1,\"m_Type\":\"\",\"m_Metadata\":\"\",\"m_Date\":\"\"}}"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Checkpoints and Portals now have vertically extending waypoints to help find them.
The waypoints get disabled based on (height-ignoring) proximity as to not distract the player.
Portals instead get a cone extending downwards; they have also been modified to spawn higher up to prevent crashing into new terrain.
Added portals to save file.
Fixed misc bugs

![image](https://github.com/rob3rtu/Unity-Project/assets/57840702/a391b3b8-860d-4e25-b70c-3d2ff3835a8c)
![image](https://github.com/rob3rtu/Unity-Project/assets/57840702/1a67ae8c-827d-4ce9-8003-0b5d989c055c)
