### PR TITLE
Implement checkpoint respawning and visual indicator

### DIFF
--- a/Flight Game/Assets/Materials/Checkpoint.mat
+++ b/Flight Game/Assets/Materials/Checkpoint.mat
@@ -130,8 +130,8 @@ Material:
     - _WorkflowMode: 1
     - _ZWrite: 0
     m_Colors:
-    - _BaseColor: {r: 1, g: 0.042452782, b: 0.059948564, a: 0.54509807}
-    - _Color: {r: 1, g: 0.042452767, b: 0.059948534, a: 0.54509807}
+    - _BaseColor: {r: 0.12806967, g: 1, b: 0.043137252, a: 0.54509807}
+    - _Color: {r: 0.12806964, g: 1, b: 0.04313723, a: 0.54509807}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []

--- a/Flight Game/Assets/Prefabs/Checkpoint.prefab
+++ b/Flight Game/Assets/Prefabs/Checkpoint.prefab
@@ -123,6 +123,11 @@ MonoBehaviour:
   generator: {fileID: 0}
   timerGain: 10
   scoreGain: 100
+  _minRespawnTime: 5
+  _maxRespawnTime: 20
+  respawnTimePercentage: 0.3
+  _material: {fileID: 2100000, guid: 4c9d8e3b773560b46a56ccb73549a710, type: 2}
+  _waypoint: {fileID: 6488252994746956878}
   _scoreCounter: {fileID: 11400000, guid: a26bdaab31ee09847b7d6acc804d23fa, type: 2}
 --- !u!1 &6488252994746956878
 GameObject:

--- a/Flight Game/Assets/Prefabs/Portal.prefab
+++ b/Flight Game/Assets/Prefabs/Portal.prefab
@@ -121,10 +121,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   countdownTimer: {fileID: 0}
   generator: {fileID: 0}
-  targetGenerator: {fileID: 0}
-  target: {fileID: -3911842569020916623, guid: 3889b86797ed22749a5350daa11ee203, type: 3}
   timerGain: 20
   scoreGain: 1000
+  _minRespawnTime: 0
+  _maxRespawnTime: 0
+  respawnTimePercentage: 1
   _scoreCounter: {fileID: 11400000, guid: a26bdaab31ee09847b7d6acc804d23fa, type: 2}
   _waypoint: {fileID: 8900662837559913722}
 --- !u!1 &8900662837559913722

--- a/Flight Game/Assets/Scenes/Main Scene.unity
+++ b/Flight Game/Assets/Scenes/Main Scene.unity
@@ -1464,7 +1464,7 @@ MonoBehaviour:
   _seed: 0
   _destroyDistance: 1000
   _usePerlinNoise: 0
-  _noise: {fileID: 2800000, guid: 1d249e344fc91a241b02054994ce530a, type: 3}
+  _noise: {fileID: 2800000, guid: cac1a882ca3c20644ae183b1189a8d91, type: 3}
   tileRandomizationFactor: 100
 --- !u!1 &660997915
 GameObject:

--- a/Flight Game/Assets/Scenes/Main Scene.unity
+++ b/Flight Game/Assets/Scenes/Main Scene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.07536813, g: 0.36652446, b: 1.2579206, a: 1}
+  m_IndirectSpecularColor: {r: 0.07534479, g: 0.36650163, b: 1.2579302, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -868,9 +868,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8667647573171359797, guid: 84e1524a5e883af40bb9feedb2dfaf36,
         type: 3}
+      propertyPath: _maxRespawnTime
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 8667647573171359797, guid: 84e1524a5e883af40bb9feedb2dfaf36,
+        type: 3}
+      propertyPath: _minRespawnTime
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8667647573171359797, guid: 84e1524a5e883af40bb9feedb2dfaf36,
+        type: 3}
       propertyPath: targetGenerator
       value: 
       objectReference: {fileID: 486563238}
+    - target: {fileID: 8667647573171359797, guid: 84e1524a5e883af40bb9feedb2dfaf36,
+        type: 3}
+      propertyPath: respawnTimePercentage
+      value: 0.1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1449,7 +1464,7 @@ MonoBehaviour:
   _seed: 0
   _destroyDistance: 1000
   _usePerlinNoise: 0
-  _noise: {fileID: 2800000, guid: cac1a882ca3c20644ae183b1189a8d91, type: 3}
+  _noise: {fileID: 2800000, guid: 1d249e344fc91a241b02054994ce530a, type: 3}
   tileRandomizationFactor: 100
 --- !u!1 &660997915
 GameObject:
@@ -3272,7 +3287,7 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 64
   _targetGenerator: {fileID: 486563237}
-  _plane: {fileID: 908505402}
+  plane: {fileID: 908505402}
   _cubeEventDurationSeconds: 10
   _cubeEventFrequency: 3
 --- !u!4 &1554781800
@@ -3302,7 +3317,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9478615bd13d94140903ef61b4bf1101, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  currentDimension: 0
+  currentDimension: 1
 --- !u!1 &1777368827
 GameObject:
   m_ObjectHideFlags: 0

--- a/Flight Game/Assets/Scripts/Checkpoints/Checkpoint.cs
+++ b/Flight Game/Assets/Scripts/Checkpoints/Checkpoint.cs
@@ -18,7 +18,7 @@ public class Checkpoint : MonoBehaviour
 
     [SerializeField]
     [Range(0f, 1f)]
-    private float respawnTimePercentage;
+    private float _respawnTimePercentage;
 
     [SerializeField]
     private Material _material;
@@ -26,10 +26,10 @@ public class Checkpoint : MonoBehaviour
     [SerializeField]
     protected GameObject _waypoint;
 
-    private Material _instanceMaterial;
-
     [SerializeField]
     protected ScoreCounterSO _scoreCounter;
+
+    private Material _instanceMaterial;
 
     protected virtual void Awake()
     {

--- a/Flight Game/Assets/Scripts/Checkpoints/CheckpointGenerator.cs
+++ b/Flight Game/Assets/Scripts/Checkpoints/CheckpointGenerator.cs
@@ -53,8 +53,7 @@ public class CheckpointGenerator : MonoBehaviour
     [SerializeField]
     private GameObject _targetGenerator;
 
-    [SerializeField]
-    private Rigidbody _plane;
+    public Rigidbody plane;
 
     [SerializeField]
     private int _cubeEventDurationSeconds;
@@ -170,7 +169,7 @@ public class CheckpointGenerator : MonoBehaviour
     {
         yield return new WaitForSeconds(_cubeEventDurationSeconds);
         _targetGenerator.GetComponent<TargetGenerator>().enabled = false;
-        Vector3 direction = Vector3.ProjectOnPlane(_plane.velocity, Vector3.down).normalized;
-        GenerateCheckpoint(direction, _plane.transform.position, null);
+        Vector3 direction = Vector3.ProjectOnPlane(plane.velocity, Vector3.down).normalized;
+        GenerateCheckpoint(direction, plane.transform.position, null);
     }
 }

--- a/Flight Game/Assets/Scripts/Checkpoints/CheckpointGenerator.cs
+++ b/Flight Game/Assets/Scripts/Checkpoints/CheckpointGenerator.cs
@@ -4,6 +4,14 @@ using UnityEngine;
 
 public class CheckpointGenerator : MonoBehaviour
 {
+    public Rigidbody plane;
+
+    [Tooltip("The Terrain Controller object")]
+    public TerrainController terrainController;
+
+    [Tooltip("Dimension Switcher object")]
+    public DimensionSwitcher switcher;
+
     [Tooltip("Checkpoint Prefab to instantiate")]
     [SerializeField]
     private Checkpoint _checkpoint;
@@ -12,15 +20,9 @@ public class CheckpointGenerator : MonoBehaviour
     [SerializeField]
     private Portal _portal;
 
-    [Tooltip("Dimension Switcher object")]
-    public DimensionSwitcher switcher;
-
     [Tooltip("How often portals should spawn instead of normal checkpoints")]
     [SerializeField]
     private int _portalFrequency;
-
-    [Tooltip("The Terrain Controller object")]
-    public TerrainController terrainController;
 
     [Tooltip("Minimum placement distance in the movement direction")]
     [SerializeField]
@@ -52,8 +54,6 @@ public class CheckpointGenerator : MonoBehaviour
 
     [SerializeField]
     private GameObject _targetGenerator;
-
-    public Rigidbody plane;
 
     [SerializeField]
     private int _cubeEventDurationSeconds;

--- a/Flight Game/Assets/Scripts/Checkpoints/Portal.cs
+++ b/Flight Game/Assets/Scripts/Checkpoints/Portal.cs
@@ -4,16 +4,16 @@ using UnityEngine;
 [RequireComponent(typeof(Collider))]
 public class Portal : Checkpoint
 {
-    [SerializeField]
-    private GameObject _waypoint;
-
     private bool _entered;
 
+    protected override void Awake() { }
+
+    protected override void Start() { }
+    
     protected override void OnTriggerEnter(Collider other)
     {
         if (!_entered && other.gameObject.CompareTag(Constants.PlayerTag))
         {
-
             StartCoroutine(TerrainCoroutine(other));
             generator.switcher.SwitchDimension();
             _scoreCounter.score.portals += 1;

--- a/Flight Game/Assets/Scripts/GUI/Countdown Timer.cs
+++ b/Flight Game/Assets/Scripts/GUI/Countdown Timer.cs
@@ -20,6 +20,7 @@ public class CountdownTimer : MonoBehaviour
 
     private float _second;
     private float _remainingTime;
+    public float RemainingTime { get { return _remainingTime; } }
 
     private void Awake() => _remainingTime = _startingTime;
 


### PR DESCRIPTION
Checkpoints now respawn after a while, in order to prevent impossible to collect checkpoints.
The respawn time is set as a configurable percentage of the remaining time with a min and max limit to prevent absurd values.
There is also a visual indication of how long until the checkpoint expires, turning from green to red.